### PR TITLE
Add role for Minecraft

### DIFF
--- a/bagbot.py
+++ b/bagbot.py
@@ -19,6 +19,7 @@ role_map = {
     '🛳️' : 'Sea of Friends',
     '🔪' : 'Among Us',
     '🍿' : 'Watch Party',
+    '⛏' : 'Minecraft',
     '💯' : 'The Living Embodiment Of The 100 Emoji'} # an emoji that connects to a non-role for testing purposes
 
 # we need member intents for role assignment to work


### PR DESCRIPTION
This PR adds support for the "Minecraft" role, using the ⛏ emoji.